### PR TITLE
feat: Demo cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
        wget https://sdk.dfinity.org/install.sh
        echo DFX_VERSION=0.6.10
        yes Y | DFX_VERSION=0.6.10 sh install.sh
-       echo "::add-path::/home/runner/bin"
+       echo "/home/runner/bin" >> $GITHUB_PATH
     - name: "dfx cache install"
       run: dfx cache install
     - name: "install vessel"

--- a/scripts/MirrorGarden-start-replica.sh
+++ b/scripts/MirrorGarden-start-replica.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 VERSION=`cat .DFX_VERSION`
 export PATH=~/.cache/dfinity/versions/$VERSION:`pwd`:$PATH
+echo
+echo Starting: Mirror Garden 2-user demo...using DFINITY SDK replica
+echo
 dfx stop &&\
 dfx start --background --clean &&\
 dfx canister create MirrorGarden &&\
 dfx build MirrorGarden &&\
-dfx canister install MirrorGarden ||\
-dfx canister install MirrorGarden --mode=reinstall &&\
-ic-gt -h &&\
-ic-gt connect 127.0.0.1:8000 `dfx canister id MirrorGarden` --user '("Alice", (100, 255, 100))'
-
+dfx canister install MirrorGarden
+ic-gt connect 127.0.0.1:8000 `dfx canister id MirrorGarden` --user '("Alice", (100, 200, 200))' &
+ic-gt connect 127.0.0.1:8000 `dfx canister id MirrorGarden` --user '("Bob", (200, 100, 200))' &
+echo
+echo Mirror Garden 2-user demo, started.
+echo


### PR DESCRIPTION
start two users when giving demos, as default demo setup benefits from two users to show the effects of message-processing concurrency on local sides and shared remote (canister) side.