### PR TITLE
feat: Draw clipboard events

### DIFF
--- a/src/lang/text/Draw.mo
+++ b/src/lang/text/Draw.mo
@@ -111,6 +111,11 @@ module {
     case (#quit) tr.textAtts("quit", txtSty(#lo));
     case (#skip) tr.textAtts("skip", txtSty(#lo));
     case (#mouseDown(pos)) tr.textAtts("mouseDown(...)", txtSty(#lo));
+    case (#clipBoard(text)) {
+           tr.textAtts("clipBoard(\"", txtSty(#vlo));
+           tr.textAtts(text, txtSty(#lo));
+           tr.textAtts("\")", txtSty(#vlo));
+         };
     case (#keyDown(ks)) {
            tr.textAtts("keyDown ", txtSty(#lo));
            for (k in ks.vals()) {


### PR DESCRIPTION
[This ic-mt PR](https://github.com/matthewhammer/ic-mini-terminal/pull/60) lists clipboard events as part of the ic-mt spec.

This PR does a complementary thing, where those clipboard events are printed.